### PR TITLE
fix "refreshToken" method in "MalAcount" class.

### DIFF
--- a/src/methods/malApi/index.ts
+++ b/src/methods/malApi/index.ts
@@ -282,8 +282,8 @@ export class MalAcount {
 
   async refreshToken(): Promise<MalAcount> {
     this.malToken = await MalToken.fromRefreshToken(
-      this.malToken.refresh_token,
-      this.clientId
+      this.clientId,
+      this.malToken.refresh_token
     );
     return this;
   }


### PR DESCRIPTION
the arguments order in "refreshToken" mehtod was reversed, so the request always returns 401 status code.