### PR TITLE
Fix Jikan4.randomUser()

### DIFF
--- a/src/methods/jikan4/random.ts
+++ b/src/methods/jikan4/random.ts
@@ -24,5 +24,5 @@ export function randomPerson(): Promise<{ data: Types.Person }> {
 
 /** @category Random*/
 export function randomUser(): Promise<{ data: Types.UserProfile }> {
-  return jikanGet(urljoin(jikanUrl, "random", "user"));
+  return jikanGet(urljoin(jikanUrl, "random", "users"));
 }

--- a/test/jikan.ts
+++ b/test/jikan.ts
@@ -362,3 +362,21 @@ describe("/club", () => {
     jikanIt(club.members({ page: 2 }), `${jikanUrl}/clubs/1/members?page=2`);
   });
 });
+
+describe("/random", () => {
+  describe("/anime", () => {
+    jikanIt(Jikan.randomAnime(), `${jikanUrl}/random/anime`);
+  });
+  describe("/manga", () => {
+    jikanIt(Jikan.randomManga(), `${jikanUrl}/random/manga`);
+  });
+  describe("/characters", () => {
+    jikanIt(Jikan.randomCharacters(), `${jikanUrl}/random/characters`);
+  });
+  describe("/people", () => {
+    jikanIt(Jikan.randomPerson(), `${jikanUrl}/random/people`);
+  });
+  describe("/users", () => {
+    jikanIt(Jikan.randomUser(), `${jikanUrl}/random/users`);
+  });
+});


### PR DESCRIPTION
## Issue
There is a typo in the `Jikan4.randomUser()` endpoint where 'user' is spelt without an 's', causing it to always throw a 404 error. The current endpoint in v4 is `/random/users`, as shown in the documentation: https://docs.api.jikan.moe/#tag/random/operation/getRandomUsers. 

## Changes

- Update `Jikan4.randomUser()` endpoint to be `/random/users`
- Added unit tests for random endpoints