### PR TITLE
Fix `list_status` on `animelist()` and `mangalist()`

### DIFF
--- a/src/methods/malApi/user/index.ts
+++ b/src/methods/malApi/user/index.ts
@@ -47,18 +47,20 @@ export class MalUser {
       url: [apiUrl, "users", name, "animelist"].join("/"),
       headers: this.acount.getHttpHeaders(),
       params: {
-        fields: "",
         nsfw: args?.includeNsfw ? "1" : "0",
       },
     };
 
-    if (fields != null) config.params.fields += fields.toString();
-
-    if (listStatusFields != null) {
-      config.params.fields += `list_status{${listStatusFields.toString()}}`;
-    } else {
-      config.params.fields += "list_status";
+    const serializedFields: string[] = []
+    if (fields != null) {
+      serializedFields.push(fields.toString());
     }
+    if (listStatusFields != null) {
+      serializedFields.push(`list_status{${listStatusFields.toString()}}`);
+    } else {
+      serializedFields.push("list_status");
+    }
+    config.params.fields = serializedFields.join(',')
 
     if (args) {
       if (args.status != null) config.params.status = args.status;
@@ -79,18 +81,19 @@ export class MalUser {
     const config: AxiosRequestConfig = {
       url: [apiUrl, "users", name, "mangalist"].join("/"),
       headers: this.acount.getHttpHeaders(),
-      params: {
-        fields: "",
-      },
+      params: {},
     };
 
-    if (fields != null) config.params.fields += fields.toString();
-
-    if (listStatusFields != null) {
-      config.params.fields += `list_status{${listStatusFields.toString()}}`;
-    } else {
-      config.params.fields += "list_status";
+    const serializedFields: string[] = []
+    if (fields != null) {
+      serializedFields.push(fields.toString());
     }
+    if (listStatusFields != null) {
+      serializedFields.push(`list_status{${listStatusFields.toString()}}`);
+    } else {
+      serializedFields.push("list_status");
+    }
+    config.params.fields = serializedFields.join(',')
 
     if (args) {
       if (args.status != null) config.params.status = args.status;


### PR DESCRIPTION
Currently when doing a `animelist()` or `mangalist()` the `list_status` is appended to the fields param without a comma separator.
This works fine if no fields are requested, but fails when one or more fields are requested.

Example url without the fix:
```
https://api.myanimelist.net/v2/users/<some user>/animelist?offset=10&fields=start_date%2Cend_date%2Cstatus%2Cnum_episodeslist_status&nsfw=1&status=plan_to_watch&limit=10
```

In the example above this results in neither the `list_status` nor the `num_episodes` being included.

This PR fixes this by ensuring we always add commas between serialized fields.